### PR TITLE
Allow login not to be an email address

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -11,7 +11,7 @@
   "categories": ["other"],
   "fields": {
     "login": {
-      "type": "email"
+      "type": "text"
     },
     "password": {
       "type": "password"


### PR DESCRIPTION
A user has reported that its login is not an email address but only numbers.